### PR TITLE
Add support for IPv6, Fix decoding MQTT message payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ This explains the meaning of some of the output:
 
 ## Contact
 
-https://github.com/ralight/mqttshark
+https://github.com/mqtt-tools/mqttshark

--- a/mqttshark
+++ b/mqttshark
@@ -877,7 +877,7 @@ def get_args():
     parser = argparse.ArgumentParser(
         prog="mqttshark",
         description="Pretty print MQTT traffic from tshark",
-        epilog="https://github.com/ralight/mqttshark"
+        epilog="https://github.com/mqtt-tools/mqttshark"
     )
     parser.add_argument(
         '-i', '--interface', action='store',

--- a/mqttshark
+++ b/mqttshark
@@ -395,6 +395,17 @@ def decode_ip_peer(packet, peer_type):
         raise ValueError(f'No "ip" or "ipv6" in packet layer')
 
 
+def decode_mqtt_payload(payload):
+    """
+    Gracefully attempt to decode MQTT message payload from UTF-8.
+    If that fails, return the original data, which is a hexlified string.
+    """
+    try:
+        return bytearray.fromhex(payload.replace(":", "")).decode("utf-8")
+    except:
+        return payload
+
+
 
 # ============================================================
 # Packet printing functions
@@ -546,7 +557,7 @@ def print_publish(args, packet, mqtt):
         return
 
     try:
-        payload = mqtt['mqtt_mqtt_msg_text']
+        payload = decode_mqtt_payload(mqtt['mqtt_mqtt_msg'])
         if len(payload) > args.truncate_payload:
             payload = payload[:args.truncate_payload] + "…"
     except KeyError:

--- a/mqttshark
+++ b/mqttshark
@@ -338,8 +338,8 @@ def print_session_ports(packet):
 
 
 def set_client_mapping(packet):
-    src = "%s:%s" % (packet['layers']['ip']['ip_ip_src'], packet['layers']['tcp']['tcp_tcp_srcport'])
-    dst = "%s:%s" % (packet['layers']['ip']['ip_ip_dst'], packet['layers']['tcp']['tcp_tcp_dstport'])
+    src = "%s:%s" % (decode_ip_peer(packet, 'src'), packet['layers']['tcp']['tcp_tcp_srcport'])
+    dst = "%s:%s" % (decode_ip_peer(packet, 'dst'), packet['layers']['tcp']['tcp_tcp_dstport'])
     try:
         c = client_mapping[src]
     except KeyError:
@@ -351,20 +351,22 @@ def set_client_mapping(packet):
 
 
 def set_client_version(packet, ver):
-    src = "%s:%s" % (packet['layers']['ip']['ip_ip_src'], packet['layers']['tcp']['tcp_tcp_srcport'])
-    dst = "%s:%s" % (packet['layers']['ip']['ip_ip_dst'], packet['layers']['tcp']['tcp_tcp_dstport'])
+    src = "%s:%s" % (decode_ip_peer(packet, 'src'), packet['layers']['tcp']['tcp_tcp_srcport'])
+    dst = "%s:%s" % (decode_ip_peer(packet, 'dst'), packet['layers']['tcp']['tcp_tcp_dstport'])
     client_versions[src] = ver
     client_versions[dst] = ver
 
+
 def get_client_version(packet):
-    src = "%s:%s" % (packet['layers']['ip']['ip_ip_src'], packet['layers']['tcp']['tcp_tcp_srcport'])
+    src = "%s:%s" % (decode_ip_peer(packet, 'src'), packet['layers']['tcp']['tcp_tcp_srcport'])
     try:
         return client_versions[src]
     except KeyError:
         return 4
 
+
 def check_client_mapping(packet):
-    src = "%s:%s" % (packet['layers']['ip']['ip_ip_src'], packet['layers']['tcp']['tcp_tcp_srcport'])
+    src = "%s:%s" % (decode_ip_peer(packet, 'src'), packet['layers']['tcp']['tcp_tcp_srcport'])
     try:
         c = client_mapping[src]
         return c
@@ -381,6 +383,16 @@ def print_origin(packet, expected=None):
             print(f" {ansi_error}{r}{ansi_reset}", end="")
     else:
         print(f" {r}", end="")
+
+
+def decode_ip_peer(packet, peer_type):
+    assert peer_type in ['src', 'dst'], f'Peer kind invalid: {peer_type}'
+    if 'ip' in packet['layers']:
+        return packet['layers']['ip'][f'ip_ip_{peer_type}']
+    elif 'ipv6' in packet['layers']:
+        return packet['layers']['ipv6'][f'ipv6_ipv6_{peer_type}']
+    else:
+        raise ValueError(f'No "ip" or "ipv6" in packet layer')
 
 
 


### PR DESCRIPTION
Dear Roger,

while approaching `mqttshark` with a little test harness to be added with GH-2, I needed this patch to make the program work on my machine. I am using macOS 10.15 and TShark 4.0.5, and connected to the loopback interface using `mqttshark -i lo0`.

Apparently, IPv6 is already spoken there, so the program needed some adjustments in this regard. Other than this, it looks like the `mqtt_mqtt_msg_text` attribute, originally emitted by TShark(?), does not exist any longer, so I tried to decode the MQTT message payload from `mqtt_mqtt_msg` instead.

Please advise if you think I got anything wrong with my changes.

With kind regards,
Andreas.
