### PR TITLE
Add basic software tests and CI configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,53 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+
+  tests:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+
+    name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
+    steps:
+
+    - name: Acquire sources
+      uses: actions/checkout@v3
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements-*.txt
+
+    - name: Setup project
+      run: |
+        pip install --use-pep517 --prefer-binary --requirement requirements-tests.txt 
+
+    - name: Run linter and software tests
+      run: |
+        pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,10 @@ jobs:
         cache-dependency-path: |
           requirements-*.txt
 
+    - name: Environment information
+      run: |
+        ifconfig
+
     - name: Setup project
       run: |
         pip install --use-pep517 --prefer-binary --requirement requirements-tests.txt 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,11 @@ jobs:
     name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
     steps:
 
+    - name: Install prerequisites
+      run: |
+        sudo apt update
+        sudo apt install --no-install-recommends --no-install-suggests --yes mosquitto-clients tshark
+
     - name: Acquire sources
       uses: actions/checkout@v3
 
@@ -46,7 +51,12 @@ jobs:
 
     - name: Environment information
       run: |
-        ifconfig
+        set -x
+        sudo ifconfig
+        sudo tshark --list-interfaces
+        sudo tshark --list-data-link-types -i lo
+        sudo tshark --list-data-link-types -i eth0
+        sudo tshark --list-data-link-types -i docker0
 
     - name: Setup project
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.idea
+/.venv*
+__pycache__
+*.pyc

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,0 +1,25 @@
+# mqttshark - development sandbox
+
+
+## Setup
+
+Acquire sources.
+```shell
+git clone https://github.com/mqtt-tools/mqttshark
+cd mqttshark
+```
+
+Install prerequisites into Python virtualenv.
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --requirement requirements-tests.txt
+```
+
+## Tests
+
+Run software tests.
+```shell
+source .venv/bin/activate
+pytest
+```

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-mqtt
+runs
+strip-ansi

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,9 +22,13 @@ def test_cli_capture(capfd, mosquitto):
     """
     Verify capturing a single MQTT PUBLISH succeeds.
     """
+    interface_name = "lo"
+    if sys.platform == "darwin":
+        interface_name = "lo0"
+
     ev = threading.Event()
     def mqttshark():
-        run_mqttshark("-i lo0")
+        run_mqttshark(f"-i {interface_name}")
     t = threading.Thread(target=mqttshark)
     t.start()
     ev.wait(0.5)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,75 @@
+import imp
+import shlex
+import sys
+import threading
+
+import runs
+
+import pytest
+from strip_ansi import strip_ansi
+
+
+def test_cli_version(capfd):
+    """
+    Verify `mqttshark --version` succeeds.
+    """
+    run_mqttshark("--version")
+    out, err = capfd.readouterr()
+    assert out.strip() == "mqttshark version 0.0.1"
+
+
+def test_cli_capture(capfd, mosquitto):
+    """
+    Verify capturing a single MQTT PUBLISH succeeds.
+    """
+    ev = threading.Event()
+    def mqttshark():
+        run_mqttshark("-i lo0")
+    t = threading.Thread(target=mqttshark)
+    t.start()
+    ev.wait(0.5)
+
+    command = """mosquitto_pub -t 'testdrive' -m '{"temperature": 42.42}'"""
+    runs.run(command)
+    ev.wait(0.25)
+
+    runs.run("sudo pkill tshark")
+    ev.wait(0.25)
+
+    out, err = capfd.readouterr()
+
+    assert out is not None, "Captured output was expected, but it is empty"
+    out = strip_ansi(out)
+    assert 'CONNECT     clientid=""  keepalive=60  cleansession=True  protover=4' in out
+    assert 'CONNACK     rc=0 (accepted)' in out
+    assert 'PUBLISH(0)  retain=0  topic="testdrive"  payload="{"temperature": 42.42}"' in out
+    assert 'DISCONNECT' in out
+
+
+def test_cli_load_module(capsys):
+    """
+    Basic test function, loading `mqttshark` as Python module.
+    This is too verbose!
+
+    :param capsys:
+    :return:
+    """
+    command = "mqttshark --version"
+    sys.argv[1:] = shlex.split(command)
+    with pytest.raises(SystemExit):
+        imp.load_source(name="mqttshark", pathname="mqttshark")
+    out, err = capsys.readouterr()
+    assert out.strip() == "mqttshark version 0.0.1"
+
+
+def run_mqttshark(arguments):
+    """
+    Utility function to invoke `mqttshark`.
+
+    :param arguments:
+    :return:
+    """
+    command = f"sudo python mqttshark {arguments}"
+    response = runs.run(command)
+    if response:
+        return response[0]


### PR DESCRIPTION
Hi again,

based upon GH-1, this patch adds a few very basic software tests, and a corresponding CI configuration on GHA, at least to make sure `mqttshark` quacks together with Mosquitto, `mosquitto_pub`, and TShark, on Linux. You can inspect a few preliminary test runs at [^1].

![image](https://github.com/mqtt-tools/mqttshark/assets/453543/56087cc9-a5f1-4f7f-9ff3-8421a6e60541)

With kind regards,
Andreas.

[^1]: https://github.com/mqtt-tools/mqttshark/actions
