### PR TITLE
Fix software tests, and improve their timing

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,7 +35,7 @@ def test_cli_capture(capfd, mosquitto):
 
     command = """mosquitto_pub -t 'testdrive' -m '{"temperature": 42.42}'"""
     runs.run(command)
-    ev.wait(0.25)
+    ev.wait(0.5)
 
     runs.run("sudo pkill tshark")
     ev.wait(0.25)
@@ -75,5 +75,4 @@ def run_mqttshark(arguments):
     """
     command = f"sudo python mqttshark {arguments}"
     response = runs.run(command)
-    if response:
-        return response[0]
+    return response


### PR DESCRIPTION
## About
What the title says. How could it have worked before?

## Details
The patch intends to address this problem.
```python
     File "/home/runner/work/mqttshark/mqttshark/tests/test_cli.py", line 31, in mqttshark
      run_mqttshark(f"-i {interface_name}")
    File "/home/runner/work/mqttshark/mqttshark/tests/test_cli.py", line 79, in run_mqttshark
      return response[0]
             ~~~~~~~~^^^
  TypeError: 'CompletedProcess' object is not subscriptable
```
-- https://github.com/mqtt-tools/mqttshark/actions/runs/8847754363/job/24751284546#step:7:78
